### PR TITLE
feat: added PhoneNumber class equality

### DIFF
--- a/core/lib/src/phonenumber.dart
+++ b/core/lib/src/phonenumber.dart
@@ -1,3 +1,5 @@
+import 'package:quiver/core.dart';
+
 import 'country.dart';
 import 'data.dart';
 
@@ -123,5 +125,26 @@ class PhoneNumber {
         country: country,
         nationalNumber: nationalNumber,
         formattedNumber: formattedNumber,
+      );
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (runtimeType == other.runtimeType &&
+            other is PhoneNumber &&
+            other.country == country &&
+            other.formattedNumber == formattedNumber &&
+            other.isValid == isValid &&
+            other.nationalNumber == nationalNumber);
+  }
+
+  @override
+  int get hashCode => hashObjects(
+        [
+          country,
+          formattedNumber,
+          isValid,
+          nationalNumber,
+        ],
       );
 }

--- a/core/test/units/phonenumber_test.dart
+++ b/core/test/units/phonenumber_test.dart
@@ -32,20 +32,20 @@ void main() {
     });
 
     test('instances should be equal', () {
-      final _tNumber = PhoneNumber.parse('994 11-2345676').formattedNumber;
+      final _tNumber = PhoneNumber.parse('994 11-2345676');
 
       expect(
         _tNumber,
-        PhoneNumber.parse('994 11-2345676').formattedNumber,
+        PhoneNumber.parse('994 11-2345676'),
       );
     });
 
     test('instances should not be equal', () {
-      final _tNumber = PhoneNumber.parse('994 11-2345675').formattedNumber;
+      final _tNumber = PhoneNumber.parse('994 11-2345675');
 
       expect(
         _tNumber,
-        isNot(PhoneNumber.parse('994 11-2345676').formattedNumber),
+        isNot(PhoneNumber.parse('994 11-2345676')),
       );
     });
   });

--- a/core/test/units/phonenumber_test.dart
+++ b/core/test/units/phonenumber_test.dart
@@ -30,5 +30,23 @@ void main() {
         '+994112345676',
       );
     });
+
+    test('instances should be equal', () {
+      final _tNumber = PhoneNumber.parse('994 11-2345676').formattedNumber;
+
+      expect(
+        _tNumber,
+        PhoneNumber.parse('994 11-2345676').formattedNumber,
+      );
+    });
+
+    test('instances should not be equal', () {
+      final _tNumber = PhoneNumber.parse('994 11-2345675').formattedNumber;
+
+      expect(
+        _tNumber,
+        isNot(PhoneNumber.parse('994 11-2345676').formattedNumber),
+      );
+    });
   });
 }


### PR DESCRIPTION
Overided the `operator` and the `hashCode` instances in the `PhoneNumber` class in order to compare two instances to see if they're equal. Also added unit tests for the change