### PR TITLE
Replace accentColor with colorScheme.secondary

### DIFF
--- a/phonenumbers/lib/src/country_dialog.dart
+++ b/phonenumbers/lib/src/country_dialog.dart
@@ -68,7 +68,7 @@ Widget _buildListTile(
     title: Text(country.name),
     trailing: Text(
       '+${country.prefix}',
-      style: theme.textTheme.bodyText1!.copyWith(color: theme.accentColor),
+      style: theme.textTheme.bodyText1!.copyWith(color: theme.colorScheme.secondary),
     ),
     leading: leading != null || showLeading
         ? DefaultTextStyle(


### PR DESCRIPTION
### What has changed:
- Replaced `theme.accentColor` with `theme.colorScheme.secondary`

### Why was this change made:
- ThemeData's accent properties have been deprecated.

### Static analysis is failing:
https://pub.dev/packages/phonenumbers/score

### Documentation:
https://docs.flutter.dev/release/breaking-changes/theme-data-accent-properties 