### PR TITLE
fix 'brazil +55' length size to account for 2 digits area code eg. 41999047777

### DIFF
--- a/core/lib/src/data.dart
+++ b/core/lib/src/data.dart
@@ -30,7 +30,7 @@ final List<Country> countries = <Country>[
   Country('Bolivia', 'BO', 591, LengthRule.exact(8)),
   Country('Bosnia and Herzegovina', 'BA', 387, LengthRule.exact(8)),
   Country('Botswana', 'BW', 267, LengthRule.range(7, 8)),
-  Country('Brazil', 'BR', 55, LengthRule.exact(10)),
+  Country('Brazil', 'BR', 55, LengthRule.exact(11)),
   Country('British Indian Ocean Territory', 'IO', 246, LengthRule.exact(7)),
   Country('British Virgin Islands', 'VG', 1284, LengthRule.exact(7)),
   Country('Brunei', 'BN', 673, LengthRule.exact(7)),


### PR DESCRIPTION
Ability to include area code + phone number.